### PR TITLE
Route finder

### DIFF
--- a/Flight Connections/Flight Connections.xcodeproj/project.pbxproj
+++ b/Flight Connections/Flight Connections.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		CAF942022AD08717002B52EE /* FlightRouteFinderProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAF942012AD08717002B52EE /* FlightRouteFinderProtocol.swift */; };
 		CAF942042AD0B1D5002B52EE /* RouteFinderError.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAF942032AD0B1D5002B52EE /* RouteFinderError.swift */; };
 		CAF942062AD0BEE4002B52EE /* City.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAF942052AD0BEE4002B52EE /* City.swift */; };
+		CAF942082AD0C7E2002B52EE /* RouteResultViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAF942072AD0C7E2002B52EE /* RouteResultViewModel.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -74,6 +75,7 @@
 		CAF942012AD08717002B52EE /* FlightRouteFinderProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlightRouteFinderProtocol.swift; sourceTree = "<group>"; };
 		CAF942032AD0B1D5002B52EE /* RouteFinderError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouteFinderError.swift; sourceTree = "<group>"; };
 		CAF942052AD0BEE4002B52EE /* City.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = City.swift; sourceTree = "<group>"; };
+		CAF942072AD0C7E2002B52EE /* RouteResultViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouteResultViewModel.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -216,6 +218,7 @@
 			isa = PBXGroup;
 			children = (
 				CA055F5F2ACB79BA0091C833 /* FlightConnectionsViewModel.swift */,
+				CAF942072AD0C7E2002B52EE /* RouteResultViewModel.swift */,
 			);
 			path = ViewModels;
 			sourceTree = "<group>";
@@ -372,6 +375,7 @@
 				CA055F4E2ACB644B0091C833 /* Connections.swift in Sources */,
 				CA055F202ACB5ED90091C833 /* FlightConnectionsApp.swift in Sources */,
 				CA055F602ACB79BA0091C833 /* FlightConnectionsViewModel.swift in Sources */,
+				CAF942082AD0C7E2002B52EE /* RouteResultViewModel.swift in Sources */,
 				CA055F502ACB66D60091C833 /* Connection.swift in Sources */,
 				CA055F522ACB66E10091C833 /* Coordinates.swift in Sources */,
 				CA055F542ACB6B590091C833 /* Coordinate.swift in Sources */,

--- a/Flight Connections/Flight Connections.xcodeproj/project.pbxproj
+++ b/Flight Connections/Flight Connections.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		9F6768C32AD03BEE00E17473 /* CalculateRouteButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F6768C22AD03BEE00E17473 /* CalculateRouteButton.swift */; };
+		9F6768C52AD0424400E17473 /* RouteResultView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F6768C42AD0424400E17473 /* RouteResultView.swift */; };
 		CA02994A2ACD93F7006D4D23 /* FlightRouteFinder.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA0299492ACD93F7006D4D23 /* FlightRouteFinder.swift */; };
 		CA055F202ACB5ED90091C833 /* FlightConnectionsApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA055F1F2ACB5ED90091C833 /* FlightConnectionsApp.swift */; };
 		CA055F222ACB5ED90091C833 /* FlightConnectionsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA055F212ACB5ED90091C833 /* FlightConnectionsView.swift */; };
@@ -49,6 +50,7 @@
 
 /* Begin PBXFileReference section */
 		9F6768C22AD03BEE00E17473 /* CalculateRouteButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculateRouteButton.swift; sourceTree = "<group>"; };
+		9F6768C42AD0424400E17473 /* RouteResultView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouteResultView.swift; sourceTree = "<group>"; };
 		CA0299492ACD93F7006D4D23 /* FlightRouteFinder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlightRouteFinder.swift; sourceTree = "<group>"; };
 		CA055F1C2ACB5ED90091C833 /* Flight Connections.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Flight Connections.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		CA055F1F2ACB5ED90091C833 /* FlightConnectionsApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlightConnectionsApp.swift; sourceTree = "<group>"; };
@@ -205,6 +207,7 @@
 			children = (
 				CA055F212ACB5ED90091C833 /* FlightConnectionsView.swift */,
 				9F6768C22AD03BEE00E17473 /* CalculateRouteButton.swift */,
+				9F6768C42AD0424400E17473 /* RouteResultView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -358,6 +361,7 @@
 				9F6768C32AD03BEE00E17473 /* CalculateRouteButton.swift in Sources */,
 				CAF942042AD0B1D5002B52EE /* RouteFinderError.swift in Sources */,
 				CAF942062AD0BEE4002B52EE /* City.swift in Sources */,
+				9F6768C52AD0424400E17473 /* RouteResultView.swift in Sources */,
 				CA3D5E442ACCD278001E58AB /* MockFlightServiceAPI.swift in Sources */,
 				CA055F572ACB6FD10091C833 /* FlightServiceAPIProtocol.swift in Sources */,
 				CA055F5C2ACB78440091C833 /* FlightServiceAPIError.swift in Sources */,

--- a/Flight Connections/Flight Connections.xcodeproj/project.pbxproj
+++ b/Flight Connections/Flight Connections.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		9F6768C32AD03BEE00E17473 /* CalculateRouteButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F6768C22AD03BEE00E17473 /* CalculateRouteButton.swift */; };
 		CA02994A2ACD93F7006D4D23 /* FlightRouteFinder.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA0299492ACD93F7006D4D23 /* FlightRouteFinder.swift */; };
 		CA055F202ACB5ED90091C833 /* FlightConnectionsApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA055F1F2ACB5ED90091C833 /* FlightConnectionsApp.swift */; };
 		CA055F222ACB5ED90091C833 /* FlightConnectionsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA055F212ACB5ED90091C833 /* FlightConnectionsView.swift */; };
@@ -47,6 +48,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		9F6768C22AD03BEE00E17473 /* CalculateRouteButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculateRouteButton.swift; sourceTree = "<group>"; };
 		CA0299492ACD93F7006D4D23 /* FlightRouteFinder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlightRouteFinder.swift; sourceTree = "<group>"; };
 		CA055F1C2ACB5ED90091C833 /* Flight Connections.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Flight Connections.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		CA055F1F2ACB5ED90091C833 /* FlightConnectionsApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlightConnectionsApp.swift; sourceTree = "<group>"; };
@@ -202,6 +204,7 @@
 			isa = PBXGroup;
 			children = (
 				CA055F212ACB5ED90091C833 /* FlightConnectionsView.swift */,
+				9F6768C22AD03BEE00E17473 /* CalculateRouteButton.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -352,6 +355,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				9F6768C32AD03BEE00E17473 /* CalculateRouteButton.swift in Sources */,
 				CAF942042AD0B1D5002B52EE /* RouteFinderError.swift in Sources */,
 				CAF942062AD0BEE4002B52EE /* City.swift in Sources */,
 				CA3D5E442ACCD278001E58AB /* MockFlightServiceAPI.swift in Sources */,

--- a/Flight Connections/Flight Connections.xcodeproj/project.pbxproj
+++ b/Flight Connections/Flight Connections.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		CA055F5C2ACB78440091C833 /* FlightServiceAPIError.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA055F5B2ACB78440091C833 /* FlightServiceAPIError.swift */; };
 		CA055F602ACB79BA0091C833 /* FlightConnectionsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA055F5F2ACB79BA0091C833 /* FlightConnectionsViewModel.swift */; };
 		CA3D5E442ACCD278001E58AB /* MockFlightServiceAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA3D5E432ACCD278001E58AB /* MockFlightServiceAPI.swift */; };
+		CA3D5E482ACCE705001E58AB /* ConnectionSelectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA3D5E472ACCE705001E58AB /* ConnectionSelectionView.swift */; };
 		CAF942022AD08717002B52EE /* FlightRouteFinderProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAF942012AD08717002B52EE /* FlightRouteFinderProtocol.swift */; };
 		CAF942042AD0B1D5002B52EE /* RouteFinderError.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAF942032AD0B1D5002B52EE /* RouteFinderError.swift */; };
 		CAF942062AD0BEE4002B52EE /* City.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAF942052AD0BEE4002B52EE /* City.swift */; };
@@ -72,6 +73,7 @@
 		CA055F5B2ACB78440091C833 /* FlightServiceAPIError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlightServiceAPIError.swift; sourceTree = "<group>"; };
 		CA055F5F2ACB79BA0091C833 /* FlightConnectionsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlightConnectionsViewModel.swift; sourceTree = "<group>"; };
 		CA3D5E432ACCD278001E58AB /* MockFlightServiceAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockFlightServiceAPI.swift; sourceTree = "<group>"; };
+		CA3D5E472ACCE705001E58AB /* ConnectionSelectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectionSelectionView.swift; sourceTree = "<group>"; };
 		CAF942012AD08717002B52EE /* FlightRouteFinderProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlightRouteFinderProtocol.swift; sourceTree = "<group>"; };
 		CAF942032AD0B1D5002B52EE /* RouteFinderError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouteFinderError.swift; sourceTree = "<group>"; };
 		CAF942052AD0BEE4002B52EE /* City.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = City.swift; sourceTree = "<group>"; };
@@ -208,6 +210,7 @@
 			isa = PBXGroup;
 			children = (
 				CA055F212ACB5ED90091C833 /* FlightConnectionsView.swift */,
+				CA3D5E472ACCE705001E58AB /* ConnectionSelectionView.swift */,
 				9F6768C22AD03BEE00E17473 /* CalculateRouteButton.swift */,
 				9F6768C42AD0424400E17473 /* RouteResultView.swift */,
 			);
@@ -375,6 +378,7 @@
 				CA055F4E2ACB644B0091C833 /* Connections.swift in Sources */,
 				CA055F202ACB5ED90091C833 /* FlightConnectionsApp.swift in Sources */,
 				CA055F602ACB79BA0091C833 /* FlightConnectionsViewModel.swift in Sources */,
+				CA3D5E482ACCE705001E58AB /* ConnectionSelectionView.swift in Sources */,
 				CAF942082AD0C7E2002B52EE /* RouteResultViewModel.swift in Sources */,
 				CA055F502ACB66D60091C833 /* Connection.swift in Sources */,
 				CA055F522ACB66E10091C833 /* Coordinates.swift in Sources */,

--- a/Flight Connections/Flight Connections.xcodeproj/project.pbxproj
+++ b/Flight Connections/Flight Connections.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		CA02994A2ACD93F7006D4D23 /* FlightRouteFinder.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA0299492ACD93F7006D4D23 /* FlightRouteFinder.swift */; };
 		CA055F202ACB5ED90091C833 /* FlightConnectionsApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA055F1F2ACB5ED90091C833 /* FlightConnectionsApp.swift */; };
 		CA055F222ACB5ED90091C833 /* FlightConnectionsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA055F212ACB5ED90091C833 /* FlightConnectionsView.swift */; };
 		CA055F242ACB5ED90091C833 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = CA055F232ACB5ED90091C833 /* Assets.xcassets */; };
@@ -23,6 +24,8 @@
 		CA055F5C2ACB78440091C833 /* FlightServiceAPIError.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA055F5B2ACB78440091C833 /* FlightServiceAPIError.swift */; };
 		CA055F602ACB79BA0091C833 /* FlightConnectionsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA055F5F2ACB79BA0091C833 /* FlightConnectionsViewModel.swift */; };
 		CA3D5E442ACCD278001E58AB /* MockFlightServiceAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA3D5E432ACCD278001E58AB /* MockFlightServiceAPI.swift */; };
+		CAF942022AD08717002B52EE /* FlightRouteFinderProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAF942012AD08717002B52EE /* FlightRouteFinderProtocol.swift */; };
+		CAF942042AD0B1D5002B52EE /* RouteFinderError.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAF942032AD0B1D5002B52EE /* RouteFinderError.swift */; };
 		CAF942062AD0BEE4002B52EE /* City.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAF942052AD0BEE4002B52EE /* City.swift */; };
 /* End PBXBuildFile section */
 
@@ -44,6 +47,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		CA0299492ACD93F7006D4D23 /* FlightRouteFinder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlightRouteFinder.swift; sourceTree = "<group>"; };
 		CA055F1C2ACB5ED90091C833 /* Flight Connections.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Flight Connections.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		CA055F1F2ACB5ED90091C833 /* FlightConnectionsApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlightConnectionsApp.swift; sourceTree = "<group>"; };
 		CA055F212ACB5ED90091C833 /* FlightConnectionsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlightConnectionsView.swift; sourceTree = "<group>"; };
@@ -63,6 +67,8 @@
 		CA055F5B2ACB78440091C833 /* FlightServiceAPIError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlightServiceAPIError.swift; sourceTree = "<group>"; };
 		CA055F5F2ACB79BA0091C833 /* FlightConnectionsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlightConnectionsViewModel.swift; sourceTree = "<group>"; };
 		CA3D5E432ACCD278001E58AB /* MockFlightServiceAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockFlightServiceAPI.swift; sourceTree = "<group>"; };
+		CAF942012AD08717002B52EE /* FlightRouteFinderProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlightRouteFinderProtocol.swift; sourceTree = "<group>"; };
+		CAF942032AD0B1D5002B52EE /* RouteFinderError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouteFinderError.swift; sourceTree = "<group>"; };
 		CAF942052AD0BEE4002B52EE /* City.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = City.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -91,6 +97,15 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		CA0299482ACD9378006D4D23 /* Utilities */ = {
+			isa = PBXGroup;
+			children = (
+				CAF942012AD08717002B52EE /* FlightRouteFinderProtocol.swift */,
+				CA0299492ACD93F7006D4D23 /* FlightRouteFinder.swift */,
+			);
+			path = Utilities;
+			sourceTree = "<group>";
+		};
 		CA055F132ACB5ED90091C833 = {
 			isa = PBXGroup;
 			children = (
@@ -117,6 +132,7 @@
 				CA055F1F2ACB5ED90091C833 /* FlightConnectionsApp.swift */,
 				CA055F552ACB6FAB0091C833 /* Services */,
 				CA055F5D2ACB79960091C833 /* Views */,
+				CA0299482ACD9378006D4D23 /* Utilities */,
 				CA055F5E2ACB79A40091C833 /* ViewModels */,
 				CA055F4C2ACB64370091C833 /* Models */,
 				CA3D5E422ACCD264001E58AB /* Mocks */,
@@ -177,6 +193,7 @@
 			isa = PBXGroup;
 			children = (
 				CA055F5B2ACB78440091C833 /* FlightServiceAPIError.swift */,
+				CAF942032AD0B1D5002B52EE /* RouteFinderError.swift */,
 			);
 			path = "Error Handling";
 			sourceTree = "<group>";
@@ -335,11 +352,14 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				CAF942042AD0B1D5002B52EE /* RouteFinderError.swift in Sources */,
 				CAF942062AD0BEE4002B52EE /* City.swift in Sources */,
 				CA3D5E442ACCD278001E58AB /* MockFlightServiceAPI.swift in Sources */,
 				CA055F572ACB6FD10091C833 /* FlightServiceAPIProtocol.swift in Sources */,
 				CA055F5C2ACB78440091C833 /* FlightServiceAPIError.swift in Sources */,
+				CAF942022AD08717002B52EE /* FlightRouteFinderProtocol.swift in Sources */,
 				CA055F222ACB5ED90091C833 /* FlightConnectionsView.swift in Sources */,
+				CA02994A2ACD93F7006D4D23 /* FlightRouteFinder.swift in Sources */,
 				CA055F592ACB6FEB0091C833 /* FlightServiceAPI.swift in Sources */,
 				CA055F4E2ACB644B0091C833 /* Connections.swift in Sources */,
 				CA055F202ACB5ED90091C833 /* FlightConnectionsApp.swift in Sources */,

--- a/Flight Connections/Flight Connections.xcodeproj/project.pbxproj
+++ b/Flight Connections/Flight Connections.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		CA055F5C2ACB78440091C833 /* FlightServiceAPIError.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA055F5B2ACB78440091C833 /* FlightServiceAPIError.swift */; };
 		CA055F602ACB79BA0091C833 /* FlightConnectionsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA055F5F2ACB79BA0091C833 /* FlightConnectionsViewModel.swift */; };
 		CA3D5E442ACCD278001E58AB /* MockFlightServiceAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA3D5E432ACCD278001E58AB /* MockFlightServiceAPI.swift */; };
+		CAF942062AD0BEE4002B52EE /* City.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAF942052AD0BEE4002B52EE /* City.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -62,6 +63,7 @@
 		CA055F5B2ACB78440091C833 /* FlightServiceAPIError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlightServiceAPIError.swift; sourceTree = "<group>"; };
 		CA055F5F2ACB79BA0091C833 /* FlightConnectionsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlightConnectionsViewModel.swift; sourceTree = "<group>"; };
 		CA3D5E432ACCD278001E58AB /* MockFlightServiceAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockFlightServiceAPI.swift; sourceTree = "<group>"; };
+		CAF942052AD0BEE4002B52EE /* City.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = City.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -157,6 +159,7 @@
 				CA055F4F2ACB66D60091C833 /* Connection.swift */,
 				CA055F512ACB66E10091C833 /* Coordinates.swift */,
 				CA055F532ACB6B590091C833 /* Coordinate.swift */,
+				CAF942052AD0BEE4002B52EE /* City.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -332,6 +335,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				CAF942062AD0BEE4002B52EE /* City.swift in Sources */,
 				CA3D5E442ACCD278001E58AB /* MockFlightServiceAPI.swift in Sources */,
 				CA055F572ACB6FD10091C833 /* FlightServiceAPIProtocol.swift in Sources */,
 				CA055F5C2ACB78440091C833 /* FlightServiceAPIError.swift in Sources */,

--- a/Flight Connections/Flight Connections/Error Handling/RouteFinderError.swift
+++ b/Flight Connections/Flight Connections/Error Handling/RouteFinderError.swift
@@ -7,6 +7,10 @@
 
 /// Represents errors that can occur when finding routes between cities using the `FlightRouteFinder`.
 enum RouteFinderError: Error {
+
+    /// Indicates that the input provided for route finding is invalid.
+    case invalidInput
+
     /// Indicates that no valid route was found between the specified cities.
-    case noValidRoute
+    case noRouteFound
 }

--- a/Flight Connections/Flight Connections/Error Handling/RouteFinderError.swift
+++ b/Flight Connections/Flight Connections/Error Handling/RouteFinderError.swift
@@ -1,0 +1,12 @@
+//
+//  RouteFinderError.swift
+//  Flight Connections
+//
+//  Created by José João Pimenta Oliveira on 06/10/2023.
+//
+
+/// Represents errors that can occur when finding routes between cities using the `FlightRouteFinder`.
+enum RouteFinderError: Error {
+    /// Indicates that no valid path was found between the specified cities.
+    case noValidPath
+}

--- a/Flight Connections/Flight Connections/Error Handling/RouteFinderError.swift
+++ b/Flight Connections/Flight Connections/Error Handling/RouteFinderError.swift
@@ -7,6 +7,6 @@
 
 /// Represents errors that can occur when finding routes between cities using the `FlightRouteFinder`.
 enum RouteFinderError: Error {
-    /// Indicates that no valid path was found between the specified cities.
-    case noValidPath
+    /// Indicates that no valid route was found between the specified cities.
+    case noValidRoute
 }

--- a/Flight Connections/Flight Connections/Models/City.swift
+++ b/Flight Connections/Flight Connections/Models/City.swift
@@ -1,0 +1,11 @@
+//
+//  City.swift
+//  Flight Connections
+//
+//  Created by José João Pimenta Oliveira on 06/10/2023.
+//
+
+struct City {
+    let name: String
+    var connections: [Connection]
+}

--- a/Flight Connections/Flight Connections/Models/Connection.swift
+++ b/Flight Connections/Flight Connections/Models/Connection.swift
@@ -12,4 +12,16 @@ struct Connection: Codable {
     let to: String?
     let coordinates: Coordinates?
     let price: Int?
+
+    init(
+        from: String?,
+        to: String?,
+        coordinates: Coordinates?,
+        price: Int?
+    ) {
+        self.from = from?.capitalized
+        self.to = to?.capitalized
+        self.coordinates = coordinates
+        self.price = price
+    }
 }

--- a/Flight Connections/Flight Connections/Models/Connection.swift
+++ b/Flight Connections/Flight Connections/Models/Connection.swift
@@ -5,8 +5,6 @@
 //  Created by José João Pimenta Oliveira on 02/10/2023.
 //
 
-import Foundation
-
 struct Connection: Codable {
     let from: String?
     let to: String?

--- a/Flight Connections/Flight Connections/Models/Connections.swift
+++ b/Flight Connections/Flight Connections/Models/Connections.swift
@@ -5,8 +5,6 @@
 //  Created by José João Pimenta Oliveira on 02/10/2023.
 //
 
-import Foundation
-
 struct Connections: Codable {
     let connections: [Connection]
 }

--- a/Flight Connections/Flight Connections/Models/Coordinate.swift
+++ b/Flight Connections/Flight Connections/Models/Coordinate.swift
@@ -5,8 +5,6 @@
 //  Created by José João Pimenta Oliveira on 02/10/2023.
 //
 
-import Foundation
-
 struct Coordinate: Codable {
     let lat: Double?
     let long: Double?

--- a/Flight Connections/Flight Connections/Models/Coordinates.swift
+++ b/Flight Connections/Flight Connections/Models/Coordinates.swift
@@ -5,8 +5,6 @@
 //  Created by José João Pimenta Oliveira on 02/10/2023.
 //
 
-import Foundation
-
 struct Coordinates: Codable {
     let from: Coordinate?
     let to: Coordinate?

--- a/Flight Connections/Flight Connections/Utilities/FlightRouteFinder.swift
+++ b/Flight Connections/Flight Connections/Utilities/FlightRouteFinder.swift
@@ -34,13 +34,22 @@ class FlightRouteFinder: FlightRouteFinderProtocol {
         }
     }
 
-    /// Attempts to find the cheapest route between two cities using the `FlightRouteFinder`.
+    /// Finds the cheapest route between two cities using the flight route finder.
     ///
     /// - Parameters:
-    ///   - departureCity: The city where the journey begins.
-    ///   - destinationCity: The city where the journey ends.
-    /// - Returns: A `Result` containing either the cheapest route (as an array of city names) and its cost or an error of type `RouteFinderError` if no valid path is found.
-    func findCheapestRoute(departureCity: String, destinationCity: String) -> Result<(path: [String], cost: Int), RouteFinderError> {
+    ///   - departureCity: The name of the departure city.
+    ///   - destinationCity: The name of the destination city.
+    ///
+    /// - Returns: A `Result` containing the cheapest route and its cost if a valid route is found, or a `RouteFinderError` if the input is invalid or no route is found.
+    func findCheapestRoute(departureCity: String, destinationCity: String) -> Result<(route: [String], cost: Int), RouteFinderError> {
+
+        guard
+            departureCity.isEmpty == false,
+            destinationCity.isEmpty == false
+        else {
+            return .failure(.invalidInput)
+        }
+
         print("\nTrying to find the cheapest connection from \(departureCity) to \(destinationCity)\n")
         var cheapestRoute: [String] = []
         var minCost = Int.max
@@ -84,7 +93,7 @@ class FlightRouteFinder: FlightRouteFinderProtocol {
 
         guard !cheapestRoute.isEmpty else {
             print("No valid route found")
-            return .failure(.noValidRoute)
+            return .failure(.noRouteFound)
         }
 
         print("Cheapest route found: \(cheapestRoute), Cost: \(minCost)")

--- a/Flight Connections/Flight Connections/Utilities/FlightRouteFinder.swift
+++ b/Flight Connections/Flight Connections/Utilities/FlightRouteFinder.swift
@@ -1,0 +1,93 @@
+//
+//  FlightRouteFinder.swift
+//  Flight Connections
+//
+//  Created by José João Pimenta Oliveira on 04/10/2023.
+//
+
+import Foundation
+
+class FlightRouteFinder: FlightRouteFinderProtocol {
+    
+    /// A collection of cities and their flight connections used for route calculations.
+    ///
+    /// The `departureCities` dictionary maps city names to `City` objects, where each `City` contains  information about the city and its *outgoing* flight connections.
+    var departureCities: [String: City] = [:]
+
+    /// Adds connections to the `FlightRouteFinder` for further route calculations.
+    ///
+    /// - Parameter connections: An array of `Connection` objects representing flight connections.
+    /// Only connections with valid 'from' and 'to' city names and non-negative prices will be added to the `FlightRouteFinder`.
+    func addConnections(_ connections: [Connection]) {
+        for connection in connections {
+            if
+                let from = connection.from, from.isEmpty == false,
+                let to = connection.to, to.isEmpty == false,
+                let price = connection.price, price >= 0
+            {
+                if departureCities[from] == nil {
+                    departureCities[from] = City(name: from, connections: [connection])
+                } else {
+                    departureCities[from]?.connections.append(connection)
+                }
+            }
+        }
+    }
+
+    /// Attempts to find the cheapest route between two cities using the `FlightRouteFinder`.
+    ///
+    /// - Parameters:
+    ///   - departureCity: The city where the journey begins.
+    ///   - destinationCity: The city where the journey ends.
+    /// - Returns: A `Result` containing either the cheapest route (as an array of city names) and its cost or an error of type `RouteFinderError` if no valid path is found.
+    func findCheapestRoute(departureCity: String, destinationCity: String) -> Result<(path: [String], cost: Int), RouteFinderError> {
+        print("\nTrying to find the cheapest connection from \(departureCity) to \(destinationCity)\n")
+        var cheapestPath: [String] = []
+        var minCost = Int.max
+
+        func exploreConnections(currentPath: [String], currentCost: Int, currentCity: String, visited: Set<String>) {
+            print("Exploring connections from: \(currentCity)")
+
+            guard currentCity != destinationCity else {
+                if currentCost < minCost {
+                    minCost = currentCost
+                    cheapestPath = currentPath
+                }
+                print("Found valid destination! Path: \(currentPath), Cost: \(currentCost)")
+                return
+            }
+
+            guard let current = departureCities[currentCity] else {
+                print("\(currentCity) has no departures. Moving on...")
+                return
+            }
+
+            for connection in current.connections {
+                if 
+                    let newCity = connection.to,
+                    visited.contains(newCity) == false,
+                    currentPath.contains(newCity) == false 
+                {
+                    let newPath = currentPath + [newCity]
+                    let newCost = currentCost + (connection.price ?? 0)
+                    exploreConnections(
+                        currentPath: newPath,
+                        currentCost: newCost,
+                        currentCity: newCity,
+                        visited: visited.union([newCity])
+                    )
+                }
+            }
+        }
+
+        exploreConnections(currentPath: [departureCity], currentCost: 0, currentCity: departureCity, visited: Set())
+
+        guard !cheapestPath.isEmpty else {
+            print("No valid path found")
+            return .failure(.noValidPath)
+        }
+
+        print("Cheapest path found: \(cheapestPath), Cost: \(minCost)")
+        return .success((cheapestPath, minCost))
+    }
+}

--- a/Flight Connections/Flight Connections/Utilities/FlightRouteFinder.swift
+++ b/Flight Connections/Flight Connections/Utilities/FlightRouteFinder.swift
@@ -42,18 +42,18 @@ class FlightRouteFinder: FlightRouteFinderProtocol {
     /// - Returns: A `Result` containing either the cheapest route (as an array of city names) and its cost or an error of type `RouteFinderError` if no valid path is found.
     func findCheapestRoute(departureCity: String, destinationCity: String) -> Result<(path: [String], cost: Int), RouteFinderError> {
         print("\nTrying to find the cheapest connection from \(departureCity) to \(destinationCity)\n")
-        var cheapestPath: [String] = []
+        var cheapestRoute: [String] = []
         var minCost = Int.max
 
-        func exploreConnections(currentPath: [String], currentCost: Int, currentCity: String, visited: Set<String>) {
+        func exploreConnections(currentRoute: [String], currentCost: Int, currentCity: String, visited: Set<String>) {
             print("Exploring connections from: \(currentCity)")
 
             guard currentCity != destinationCity else {
                 if currentCost < minCost {
                     minCost = currentCost
-                    cheapestPath = currentPath
+                    cheapestRoute = currentRoute
                 }
-                print("Found valid destination! Path: \(currentPath), Cost: \(currentCost)")
+                print("Found valid destination! Route: \(currentRoute), Cost: \(currentCost)")
                 return
             }
 
@@ -66,12 +66,12 @@ class FlightRouteFinder: FlightRouteFinderProtocol {
                 if 
                     let newCity = connection.to,
                     visited.contains(newCity) == false,
-                    currentPath.contains(newCity) == false 
+                    currentRoute.contains(newCity) == false
                 {
-                    let newPath = currentPath + [newCity]
+                    let newRoute = currentRoute + [newCity]
                     let newCost = currentCost + (connection.price ?? 0)
                     exploreConnections(
-                        currentPath: newPath,
+                        currentRoute: newRoute,
                         currentCost: newCost,
                         currentCity: newCity,
                         visited: visited.union([newCity])
@@ -80,14 +80,14 @@ class FlightRouteFinder: FlightRouteFinderProtocol {
             }
         }
 
-        exploreConnections(currentPath: [departureCity], currentCost: 0, currentCity: departureCity, visited: Set())
+        exploreConnections(currentRoute: [departureCity], currentCost: 0, currentCity: departureCity, visited: Set())
 
-        guard !cheapestPath.isEmpty else {
-            print("No valid path found")
-            return .failure(.noValidPath)
+        guard !cheapestRoute.isEmpty else {
+            print("No valid route found")
+            return .failure(.noValidRoute)
         }
 
-        print("Cheapest path found: \(cheapestPath), Cost: \(minCost)")
-        return .success((cheapestPath, minCost))
+        print("Cheapest route found: \(cheapestRoute), Cost: \(minCost)")
+        return .success((cheapestRoute, minCost))
     }
 }

--- a/Flight Connections/Flight Connections/Utilities/FlightRouteFinderProtocol.swift
+++ b/Flight Connections/Flight Connections/Utilities/FlightRouteFinderProtocol.swift
@@ -1,0 +1,24 @@
+//
+//  FlightRouteFinderProtocol.swift
+//  Flight Connections
+//
+//  Created by José João Pimenta Oliveira on 06/10/2023.
+//
+
+import Foundation
+
+/// A protocol for finding the cheapest flight route between two cities.
+protocol FlightRouteFinderProtocol {
+    /// Adds flight connections to the route finder's data.
+    ///
+    /// - Parameter connections: An array of `Connection` objects representing flight connections.
+    func addConnections(_ connections: [Connection])
+
+    /// Finds the cheapest flight route between the specified departure and destination cities.
+    ///
+    /// - Parameters:
+    ///   - departureCity: The name of the departure city.
+    ///   - destinationCity: The name of the destination city.
+    /// - Returns: A `Result` containing either the cheapest flight route and cost or an error.
+    func findCheapestRoute(departureCity: String, destinationCity: String) -> Result<(path: [String], cost: Int), RouteFinderError>
+}

--- a/Flight Connections/Flight Connections/Utilities/FlightRouteFinderProtocol.swift
+++ b/Flight Connections/Flight Connections/Utilities/FlightRouteFinderProtocol.swift
@@ -14,11 +14,15 @@ protocol FlightRouteFinderProtocol {
     /// - Parameter connections: An array of `Connection` objects representing flight connections.
     func addConnections(_ connections: [Connection])
 
-    /// Finds the cheapest flight route between the specified departure and destination cities.
+    /// Finds the cheapest route between two cities.
     ///
     /// - Parameters:
     ///   - departureCity: The name of the departure city.
     ///   - destinationCity: The name of the destination city.
-    /// - Returns: A `Result` containing either the cheapest flight route and cost or an error.
-    func findCheapestRoute(departureCity: String, destinationCity: String) -> Result<(path: [String], cost: Int), RouteFinderError>
+    ///
+    /// - Returns: A `Result` containing the cheapest route and its cost if a valid route is found, or a `RouteFinderError` if the input is invalid or no route is found.
+    func findCheapestRoute(
+        departureCity: String,
+        destinationCity: String
+    ) -> Result<(route: [String], cost: Int), RouteFinderError>
 }

--- a/Flight Connections/Flight Connections/ViewModels/RouteResultViewModel.swift
+++ b/Flight Connections/Flight Connections/ViewModels/RouteResultViewModel.swift
@@ -1,0 +1,30 @@
+//
+//  RouteResultViewModel.swift
+//  Flight Connections
+//
+//  Created by José João Pimenta Oliveira on 06/10/2023.
+//
+
+import Foundation
+
+class RouteResultViewModel: ObservableObject {
+    @Published var resultText: String = ""
+
+    func updateResultText(result: Result<(path: [String], cost: Int), RouteFinderError>) {
+        switch result {
+        case .success(let connection):
+            if connection.path.count == 1 {
+                if connection.path.first?.isEmpty ?? true {
+                    resultText = ""
+                } else {
+                    resultText = "You could just walk, you know? 🚶🏻‍♂️"
+                }
+            } else {
+                resultText = "\(connection.path.joined(separator: " -> "))\nTravel costs: \(connection.cost)"
+            }
+
+        case .failure(let error):
+            resultText = "No connection found: \(error)"
+        }
+    }
+}

--- a/Flight Connections/Flight Connections/ViewModels/RouteResultViewModel.swift
+++ b/Flight Connections/Flight Connections/ViewModels/RouteResultViewModel.swift
@@ -20,7 +20,7 @@ class RouteResultViewModel: ObservableObject {
                     resultText = "You could just walk, you know? 🚶🏻‍♂️"
                 }
             } else {
-                resultText = "\(connection.path.joined(separator: " -> "))\nTravel costs: \(connection.cost)"
+                resultText = "\(connection.route.joined(separator: " -> "))\nTravel costs: \(connection.cost)"
             }
 
         case .failure(let error):

--- a/Flight Connections/Flight Connections/ViewModels/RouteResultViewModel.swift
+++ b/Flight Connections/Flight Connections/ViewModels/RouteResultViewModel.swift
@@ -10,15 +10,11 @@ import Foundation
 class RouteResultViewModel: ObservableObject {
     @Published var resultText: String = ""
 
-    func updateResultText(result: Result<(path: [String], cost: Int), RouteFinderError>) {
+    func updateResultText(result: Result<(route: [String], cost: Int), RouteFinderError>) {
         switch result {
         case .success(let connection):
-            if connection.path.count == 1 {
-                if connection.path.first?.isEmpty ?? true {
-                    resultText = ""
-                } else {
-                    resultText = "You could just walk, you know? 🚶🏻‍♂️"
-                }
+            if connection.route.count == 1 {
+                resultText = "You could just walk, you know? 🚶🏻‍♂️"
             } else {
                 resultText = "\(connection.route.joined(separator: " -> "))\nTravel costs: \(connection.cost)"
             }

--- a/Flight Connections/Flight Connections/Views/CalculateRouteButton.swift
+++ b/Flight Connections/Flight Connections/Views/CalculateRouteButton.swift
@@ -1,0 +1,25 @@
+//
+//  CalculateRouteButton.swift
+//  Flight Connections
+//
+//  Created by José Oliveira on 06/10/2023.
+//
+
+import SwiftUI
+
+struct CalculateRouteButton: View {
+    var action: () -> Void
+
+    var body: some View {
+        Button("Calculate Cheapest Route") {
+            action()
+        }
+        .padding()
+    }
+}
+
+#Preview {
+    CalculateRouteButton(action: {
+        print("Button pressed")
+    })
+}

--- a/Flight Connections/Flight Connections/Views/ConnectionSelectionView.swift
+++ b/Flight Connections/Flight Connections/Views/ConnectionSelectionView.swift
@@ -1,0 +1,49 @@
+//
+//  ConnectionSelectionView.swift
+//  Flight Connections
+//
+//  Created by José João Pimenta Oliveira on 04/10/2023.
+//
+
+import SwiftUI
+
+struct ConnectionSelectionView: View {
+
+    @Binding var selectedDepartureCity: String
+    @Binding var selectedDestinationCity: String
+
+    var buttonAction: () -> Void
+
+    var body: some View {
+        VStack {
+            Text("Select Departure City:")
+                .font(.headline)
+
+            TextField("Departure City", text: $selectedDepartureCity)
+            .autocapitalization(.words)
+            .textFieldStyle(.roundedBorder)
+
+            Text("Select Destination City:")
+                .font(.headline)
+
+            TextField("Destination City", text: $selectedDestinationCity)
+            .autocapitalization(.words)
+            .textFieldStyle(.roundedBorder)
+
+            CalculateRouteButton {
+                buttonAction()
+            }
+
+            Spacer()
+        }
+        .padding()
+    }
+}
+
+#Preview {
+    ConnectionSelectionView(
+        selectedDepartureCity: .constant("Departure City"),
+        selectedDestinationCity: .constant("Destination City"),
+        buttonAction: { }
+    )
+}

--- a/Flight Connections/Flight Connections/Views/FlightConnectionsView.swift
+++ b/Flight Connections/Flight Connections/Views/FlightConnectionsView.swift
@@ -9,6 +9,8 @@ import SwiftUI
 
 struct FlightConnectionsView: View {
     @StateObject private var viewModel = FlightConnectionsViewModel()
+    @ObservedObject private var routeResultViewModel = RouteResultViewModel()
+    @State private var routeFinderResult: Result<(route: [String], cost: Int), RouteFinderError> = .failure(.invalidInput)
 
     var body: some View {
         VStack {
@@ -16,11 +18,13 @@ struct FlightConnectionsView: View {
             case .loading:
                 ProgressView()
 
-            case .fetched(let connections):
-                Text(connections.connections.first?.from ?? "")
+            case .fetched:
+                RouteResultView(routeResultViewModel: routeResultViewModel)
 
             case .error(let error):
                 Text("Error occurred: \(error.localizedDescription)")
+                    .font(.headline)
+                    .padding()
             }
         }
         .task {

--- a/Flight Connections/Flight Connections/Views/FlightConnectionsView.swift
+++ b/Flight Connections/Flight Connections/Views/FlightConnectionsView.swift
@@ -10,6 +10,9 @@ import SwiftUI
 struct FlightConnectionsView: View {
     @StateObject private var viewModel = FlightConnectionsViewModel()
     @ObservedObject private var routeResultViewModel = RouteResultViewModel()
+
+    @State private var selectedDepartureCity: String = ""
+    @State private var selectedDestinationCity: String = ""
     @State private var routeFinderResult: Result<(route: [String], cost: Int), RouteFinderError> = .failure(.invalidInput)
 
     var body: some View {
@@ -19,6 +22,19 @@ struct FlightConnectionsView: View {
                 ProgressView()
 
             case .fetched:
+                ConnectionSelectionView(
+                    selectedDepartureCity: $selectedDepartureCity,
+                    selectedDestinationCity: $selectedDestinationCity,
+                    buttonAction: {
+                        routeFinderResult = viewModel.findCheapestRoute(
+                            departureCity: selectedDepartureCity.capitalized.trimmingCharacters(in: .whitespacesAndNewlines),
+                            destinationCity: selectedDestinationCity.capitalized.trimmingCharacters(in: .whitespacesAndNewlines)
+                        )
+
+                        routeResultViewModel.updateResultText(result: routeFinderResult)
+                    }
+                )
+
                 RouteResultView(routeResultViewModel: routeResultViewModel)
 
             case .error(let error):

--- a/Flight Connections/Flight Connections/Views/RouteResultView.swift
+++ b/Flight Connections/Flight Connections/Views/RouteResultView.swift
@@ -1,0 +1,39 @@
+//
+//  RouteResultView.swift
+//  Flight Connections
+//
+//  Created by José Oliveira on 06/10/2023.
+//
+
+import SwiftUI
+
+struct RouteResultView: View {
+    let result: Result<(path: [String], cost: Int), RouteFinderError>
+
+    var body: some View {
+        Text(resultText)
+            .font(.headline)
+            .padding()
+            .multilineTextAlignment(.center)
+    }
+
+    private var resultText: String {
+        switch result {
+        case .success(let connection):
+            if connection.path.count == 1 {
+                if connection.path.first?.isEmpty ?? true {
+                    return ""
+                }
+                return "You could just walk, you know? 🚶🏻‍♂️"
+            }
+            return "\(connection.path.joined(separator: " -> "))\nTravel costs: \(connection.cost)"
+
+        case .failure(let error):
+            return "No connection found: \(error)"
+        }
+    }
+}
+
+#Preview {
+    RouteResultView(result: .success((path: ["Tokyo", "London", "Porto", "Cape Town"], cost: 100)))
+}

--- a/Flight Connections/Flight Connections/Views/RouteResultView.swift
+++ b/Flight Connections/Flight Connections/Views/RouteResultView.swift
@@ -8,32 +8,16 @@
 import SwiftUI
 
 struct RouteResultView: View {
-    let result: Result<(path: [String], cost: Int), RouteFinderError>
+    @ObservedObject var routeResultViewModel: RouteResultViewModel
 
     var body: some View {
-        Text(resultText)
+        Text(routeResultViewModel.resultText)
             .font(.headline)
             .padding()
             .multilineTextAlignment(.center)
     }
-
-    private var resultText: String {
-        switch result {
-        case .success(let connection):
-            if connection.path.count == 1 {
-                if connection.path.first?.isEmpty ?? true {
-                    return ""
-                }
-                return "You could just walk, you know? 🚶🏻‍♂️"
-            }
-            return "\(connection.path.joined(separator: " -> "))\nTravel costs: \(connection.cost)"
-
-        case .failure(let error):
-            return "No connection found: \(error)"
-        }
-    }
 }
 
 #Preview {
-    RouteResultView(result: .success((path: ["Tokyo", "London", "Porto", "Cape Town"], cost: 100)))
+    RouteResultView(routeResultViewModel: RouteResultViewModel())
 }

--- a/Flight Connections/Flight ConnectionsTests/Flight_ConnectionsTests.swift
+++ b/Flight Connections/Flight ConnectionsTests/Flight_ConnectionsTests.swift
@@ -12,10 +12,156 @@ final class Flight_ConnectionsTests: XCTestCase {
 
     var mockFlightService: MockFlightServiceAPI = MockFlightServiceAPI()
     var flightViewModel: FlightConnectionsViewModel?
+    var flightRouteFinder: FlightRouteFinder = FlightRouteFinder()
+
+    let jsonData = """
+ {
+   "connections": [
+     {
+       "from": "London",
+       "to": "Tokyo",
+       "coordinates": {
+         "from": {
+           "lat": 51.5285582,
+           "long": -0.241681
+         },
+         "to": {
+           "lat": 35.652832,
+           "long": 139.839478
+         }
+       },
+       "price": 220
+     },
+     {
+       "from": "Tokyo",
+       "to": "London",
+       "coordinates": {
+         "from": {
+           "lat": 35.652832,
+           "long": 139.839478
+         },
+         "to": {
+           "lat": 51.5285582,
+           "long": -0.241681
+         }
+       },
+       "price": 200
+     },
+     {
+       "from": "London",
+       "to": "Porto",
+       "price": 50,
+       "coordinates": {
+         "from": {
+           "lat": 51.5285582,
+           "long": -0.241681
+         },
+         "to": {
+           "lat": 41.14961,
+           "long": -8.61099
+         }
+       }
+     },
+     {
+       "from": "Tokyo",
+       "to": "Sydney",
+       "price": 100,
+       "coordinates": {
+         "from": {
+           "lat": 35.652832,
+           "long": 139.839478
+         },
+         "to": {
+           "lat": -33.865143,
+           "long": 151.2099
+         }
+       }
+     },
+     {
+       "from": "Sydney",
+       "to": "Cape Town",
+       "price": 200,
+       "coordinates": {
+         "from": {
+           "lat": -33.865143,
+           "long": 151.2099
+         },
+         "to": {
+           "lat": -33.918861,
+           "long": 18.4233
+         }
+       }
+     },
+     {
+       "from": "Cape Town",
+       "to": "London",
+       "price": 800,
+       "coordinates": {
+         "from": {
+           "lat": -33.918861,
+           "long": 18.4233
+         },
+         "to": {
+           "lat": 51.5285582,
+           "long": -0.241681
+         }
+       }
+     },
+     {
+       "from": "London",
+       "to": "New York",
+       "price": 400,
+       "coordinates": {
+         "from": {
+           "lat": 51.5285582,
+           "long": -0.241681
+         },
+         "to": {
+           "lat": 40.73061,
+           "long": -73.935242
+         }
+       }
+     },
+     {
+       "from": "New York",
+       "to": "Los Angeles",
+       "price": 120,
+       "coordinates": {
+         "from": {
+           "lat": 40.73061,
+           "long": -73.935242
+         },
+         "to": {
+           "lat": 34.052235,
+           "long": -118.243683
+         }
+       }
+     },
+     {
+       "from": "Los Angeles",
+       "to": "Tokyo",
+       "price": 150,
+       "coordinates": {
+         "from": {
+           "lat": 34.052235,
+           "long": -118.243683
+         },
+         "to": {
+           "lat": 35.652832,
+           "long": 139.839478
+         }
+       }
+     }
+   ]
+ }
+"""
 
     override func setUp() {
         super.setUp()
-        flightViewModel = FlightConnectionsViewModel(flightService: mockFlightService)
+        flightViewModel = FlightConnectionsViewModel(
+            flightService: mockFlightService,
+            flightRouteFinder: flightRouteFinder
+        )
     }
 
     override func tearDown() {
@@ -39,5 +185,163 @@ final class Flight_ConnectionsTests: XCTestCase {
 
         XCTAssertTrue(mockFlightService.didCallFetchFlightConnections)
         XCTAssertEqual(flightViewModel?.connections?.connections.count, nil)
+    }
+
+    func test_FindCheapestConnection_Success() {
+        var connections: Connections?
+        if let jsonData = jsonData.data(using: .utf8) {
+            do {
+                connections = try JSONDecoder().decode(Connections.self, from: jsonData)
+            } catch {
+                print("Error decoding JSON: \(error)")
+            }
+        }
+
+        flightRouteFinder.addConnections(connections?.connections ?? [])
+
+        let result1 = flightViewModel?.findCheapestRoute(departureCity: "Tokyo", destinationCity: "Sydney") ?? .failure(.noValidPath)
+        let result2 = flightViewModel?.findCheapestRoute(departureCity: "London", destinationCity: "Sydney") ?? .failure(.noValidPath)
+        let result3 = flightViewModel?.findCheapestRoute(departureCity: "los angeles", destinationCity: "CAPE TOWN") ?? .failure(.noValidPath)
+
+        XCTAssertNotNil(result1)
+        XCTAssertNotNil(result2)
+
+        switch result1 {
+        case .success(let (path, cost)):
+            XCTAssertEqual(cost, 100)
+            XCTAssertEqual(path, ["Tokyo", "Sydney"])
+
+        case .failure(let error):
+            XCTFail("Error finding cheapest route: \(error)")
+        }
+
+        switch result2 {
+        case .success(let (path, cost)):
+            XCTAssertEqual(cost, 320)
+            XCTAssertEqual(path, ["London", "Tokyo", "Sydney"])
+
+        case .failure(let error):
+            XCTFail("Error finding cheapest route: \(error)")
+        }
+
+        switch result3 {
+        case .success(let (path, cost)):
+            XCTAssertEqual(cost, 450)
+            XCTAssertEqual(path, ["Los Angeles", "Tokyo", "Sydney", "Cape Town"])
+
+        case .failure(let error):
+            XCTFail("Error finding cheapest route: \(error)")
+        }
+    }
+
+    func test_FindCheapestConnection_Duplicate_Success() {
+        var connections: Connections?
+        if let jsonData = jsonData.data(using: .utf8) {
+            do {
+                connections = try JSONDecoder().decode(Connections.self, from: jsonData)
+            } catch {
+                print("Error decoding JSON: \(error)")
+            }
+        }
+
+        flightRouteFinder.addConnections(connections?.connections ?? [])
+        let result = flightViewModel?.findCheapestRoute(departureCity: "Tokyo", destinationCity: "Tokyo") ?? .failure(.noValidPath)
+
+        XCTAssertNotNil(result)
+
+        switch result {
+        case .success(let (path, cost)):
+            XCTAssertEqual(cost, 0)
+            XCTAssertEqual(path, ["Tokyo"])
+
+        case .failure(let error):
+            XCTFail("Error finding cheapest route: \(error)")
+        }
+    }
+
+    func test_FindCheapestConnection_NoConnectionFound_Failure() {
+        var connections: Connections?
+        if let jsonData = jsonData.data(using: .utf8) {
+            do {
+                connections = try JSONDecoder().decode(Connections.self, from: jsonData)
+            } catch {
+                print("Error decoding JSON: \(error)")
+            }
+        }
+
+        flightRouteFinder.addConnections(connections?.connections ?? [])
+        let result = flightViewModel?.findCheapestRoute(
+            departureCity: "Guimarães",
+            destinationCity: "Porto"
+        ) ?? .success(([""], 10))
+
+        XCTAssertNotNil(result)
+
+        switch result {
+        case .success:
+            XCTFail("No path should have been found")
+
+        case .failure(let error):
+            XCTAssertEqual(error, .noValidPath)
+        }
+    }
+
+    func test_AddConnections_Success() {
+        var connections: Connections?
+        if let jsonData = jsonData.data(using: .utf8) {
+            do {
+                connections = try JSONDecoder().decode(Connections.self, from: jsonData)
+            } catch {
+                XCTFail("Error decoding JSON: \(error)")
+            }
+        }
+
+        flightRouteFinder.addConnections(
+            connections?.connections ?? []
+        )
+
+        XCTAssertEqual(flightRouteFinder.departureCities.count, 6)
+        XCTAssertEqual(flightRouteFinder.departureCities["Los Angeles"]?.connections.count, 1)
+        XCTAssertEqual(flightRouteFinder.departureCities["London"]?.connections.count, 3)
+        XCTAssertEqual(flightRouteFinder.departureCities["Porto"]?.connections.count, nil)
+        XCTAssertEqual(flightRouteFinder.departureCities["Sydney"]?.connections.first?.to, "Cape Town")
+        XCTAssertEqual(flightRouteFinder.departureCities["Sydney"]?.connections.first?.from, "Sydney")
+        XCTAssertEqual(flightRouteFinder.departureCities["New York"]?.connections.first?.to, "Los Angeles")
+        XCTAssertEqual(flightRouteFinder.departureCities["New York"]?.connections.first?.price, 120)
+    }
+
+    func test_AddConnection_Failure() {
+        flightRouteFinder.departureCities.removeAll()
+        flightRouteFinder.addConnections([
+            Connection(
+                from: "",
+                to: "Destination",
+                coordinates: Coordinates(
+                    from: Coordinate(lat: 10, long: 20),
+                    to: Coordinate(lat: 10, long: 20)
+                ),
+                price: 100
+            ),
+            Connection(
+                from: "Source",
+                to: "",
+                coordinates: Coordinates(
+                    from: Coordinate(lat: 10, long: 20),
+                    to: Coordinate(lat: 10, long: 20)
+                ),                
+                price: 100
+            ),
+            Connection(
+                from: "Source",
+                to: "Destination",
+                coordinates: Coordinates(
+                    from: Coordinate(lat: 10, long: 20),
+                    to: Coordinate(lat: 10, long: 20)
+                ),
+                price: -50
+            )
+        ])
+
+        XCTAssertEqual(flightRouteFinder.departureCities.count, 0)
     }
 }

--- a/Flight Connections/Flight ConnectionsTests/Flight_ConnectionsTests.swift
+++ b/Flight Connections/Flight ConnectionsTests/Flight_ConnectionsTests.swift
@@ -14,147 +14,157 @@ final class Flight_ConnectionsTests: XCTestCase {
     var flightViewModel: FlightConnectionsViewModel?
     var flightRouteFinder: FlightRouteFinder = FlightRouteFinder()
 
-    let jsonData = """
- {
-   "connections": [
-     {
-       "from": "London",
-       "to": "Tokyo",
-       "coordinates": {
-         "from": {
-           "lat": 51.5285582,
-           "long": -0.241681
-         },
-         "to": {
-           "lat": 35.652832,
-           "long": 139.839478
+    func loadConnectionsFromJSON() -> Connections? {
+        let jsonData = """
+         {
+           "connections": [
+             {
+               "from": "London",
+               "to": "Tokyo",
+               "coordinates": {
+                 "from": {
+                   "lat": 51.5285582,
+                   "long": -0.241681
+                 },
+                 "to": {
+                   "lat": 35.652832,
+                   "long": 139.839478
+                 }
+               },
+               "price": 220
+             },
+             {
+               "from": "Tokyo",
+               "to": "London",
+               "coordinates": {
+                 "from": {
+                   "lat": 35.652832,
+                   "long": 139.839478
+                 },
+                 "to": {
+                   "lat": 51.5285582,
+                   "long": -0.241681
+                 }
+               },
+               "price": 200
+             },
+             {
+               "from": "London",
+               "to": "Porto",
+               "price": 50,
+               "coordinates": {
+                 "from": {
+                   "lat": 51.5285582,
+                   "long": -0.241681
+                 },
+                 "to": {
+                   "lat": 41.14961,
+                   "long": -8.61099
+                 }
+               }
+             },
+             {
+               "from": "Tokyo",
+               "to": "Sydney",
+               "price": 100,
+               "coordinates": {
+                 "from": {
+                   "lat": 35.652832,
+                   "long": 139.839478
+                 },
+                 "to": {
+                   "lat": -33.865143,
+                   "long": 151.2099
+                 }
+               }
+             },
+             {
+               "from": "Sydney",
+               "to": "Cape Town",
+               "price": 200,
+               "coordinates": {
+                 "from": {
+                   "lat": -33.865143,
+                   "long": 151.2099
+                 },
+                 "to": {
+                   "lat": -33.918861,
+                   "long": 18.4233
+                 }
+               }
+             },
+             {
+               "from": "Cape Town",
+               "to": "London",
+               "price": 800,
+               "coordinates": {
+                 "from": {
+                   "lat": -33.918861,
+                   "long": 18.4233
+                 },
+                 "to": {
+                   "lat": 51.5285582,
+                   "long": -0.241681
+                 }
+               }
+             },
+             {
+               "from": "London",
+               "to": "New York",
+               "price": 400,
+               "coordinates": {
+                 "from": {
+                   "lat": 51.5285582,
+                   "long": -0.241681
+                 },
+                 "to": {
+                   "lat": 40.73061,
+                   "long": -73.935242
+                 }
+               }
+             },
+             {
+               "from": "New York",
+               "to": "Los Angeles",
+               "price": 120,
+               "coordinates": {
+                 "from": {
+                   "lat": 40.73061,
+                   "long": -73.935242
+                 },
+                 "to": {
+                   "lat": 34.052235,
+                   "long": -118.243683
+                 }
+               }
+             },
+             {
+               "from": "Los Angeles",
+               "to": "Tokyo",
+               "price": 150,
+               "coordinates": {
+                 "from": {
+                   "lat": 34.052235,
+                   "long": -118.243683
+                 },
+                 "to": {
+                   "lat": 35.652832,
+                   "long": 139.839478
+                 }
+               }
+             }
+           ]
          }
-       },
-       "price": 220
-     },
-     {
-       "from": "Tokyo",
-       "to": "London",
-       "coordinates": {
-         "from": {
-           "lat": 35.652832,
-           "long": 139.839478
-         },
-         "to": {
-           "lat": 51.5285582,
-           "long": -0.241681
-         }
-       },
-       "price": 200
-     },
-     {
-       "from": "London",
-       "to": "Porto",
-       "price": 50,
-       "coordinates": {
-         "from": {
-           "lat": 51.5285582,
-           "long": -0.241681
-         },
-         "to": {
-           "lat": 41.14961,
-           "long": -8.61099
-         }
-       }
-     },
-     {
-       "from": "Tokyo",
-       "to": "Sydney",
-       "price": 100,
-       "coordinates": {
-         "from": {
-           "lat": 35.652832,
-           "long": 139.839478
-         },
-         "to": {
-           "lat": -33.865143,
-           "long": 151.2099
-         }
-       }
-     },
-     {
-       "from": "Sydney",
-       "to": "Cape Town",
-       "price": 200,
-       "coordinates": {
-         "from": {
-           "lat": -33.865143,
-           "long": 151.2099
-         },
-         "to": {
-           "lat": -33.918861,
-           "long": 18.4233
-         }
-       }
-     },
-     {
-       "from": "Cape Town",
-       "to": "London",
-       "price": 800,
-       "coordinates": {
-         "from": {
-           "lat": -33.918861,
-           "long": 18.4233
-         },
-         "to": {
-           "lat": 51.5285582,
-           "long": -0.241681
-         }
-       }
-     },
-     {
-       "from": "London",
-       "to": "New York",
-       "price": 400,
-       "coordinates": {
-         "from": {
-           "lat": 51.5285582,
-           "long": -0.241681
-         },
-         "to": {
-           "lat": 40.73061,
-           "long": -73.935242
-         }
-       }
-     },
-     {
-       "from": "New York",
-       "to": "Los Angeles",
-       "price": 120,
-       "coordinates": {
-         "from": {
-           "lat": 40.73061,
-           "long": -73.935242
-         },
-         "to": {
-           "lat": 34.052235,
-           "long": -118.243683
-         }
-       }
-     },
-     {
-       "from": "Los Angeles",
-       "to": "Tokyo",
-       "price": 150,
-       "coordinates": {
-         "from": {
-           "lat": 34.052235,
-           "long": -118.243683
-         },
-         "to": {
-           "lat": 35.652832,
-           "long": 139.839478
-         }
-       }
-     }
-   ]
- }
-"""
+        """
+            .data(using: .utf8)
+
+        do {
+            return try JSONDecoder().decode(Connections.self, from: jsonData ?? Data())
+        } catch {
+            XCTFail("Error decoding JSON: \(error)")
+            return nil
+        }
+    }
 
     override func setUp() {
         super.setUp()
@@ -178,7 +188,7 @@ final class Flight_ConnectionsTests: XCTestCase {
         XCTAssertEqual(flightViewModel?.connections?.connections.count, 2)
     }
 
-    func test_FetchFlightConnections_Failure() async {
+    func test_FetchFlightConnections_Failure_InvalidResponse() async {
         mockFlightService.fetchFlightConnectionsError = .invalidResponse
 
         await flightViewModel?.fetchFlightConnections()
@@ -187,15 +197,8 @@ final class Flight_ConnectionsTests: XCTestCase {
         XCTAssertEqual(flightViewModel?.connections?.connections.count, nil)
     }
 
-    func test_FindCheapestConnection_Success() {
-        var connections: Connections?
-        if let jsonData = jsonData.data(using: .utf8) {
-            do {
-                connections = try JSONDecoder().decode(Connections.self, from: jsonData)
-            } catch {
-                print("Error decoding JSON: \(error)")
-            }
-        }
+    func test_FindCheapestConnection_SuccessfulRoute() {
+        let connections = loadConnectionsFromJSON()
 
         flightRouteFinder.addConnections(connections?.connections ?? [])
 
@@ -234,15 +237,8 @@ final class Flight_ConnectionsTests: XCTestCase {
         }
     }
 
-    func test_FindCheapestConnection_Duplicate_Success() {
-        var connections: Connections?
-        if let jsonData = jsonData.data(using: .utf8) {
-            do {
-                connections = try JSONDecoder().decode(Connections.self, from: jsonData)
-            } catch {
-                print("Error decoding JSON: \(error)")
-            }
-        }
+    func test_FindCheapestConnection_Success_Duplicate() {
+        let connections = loadConnectionsFromJSON()
 
         flightRouteFinder.addConnections(connections?.connections ?? [])
         let result = flightViewModel?.findCheapestRoute(
@@ -262,15 +258,8 @@ final class Flight_ConnectionsTests: XCTestCase {
         }
     }
 
-    func test_FindCheapestConnection_NoConnectionFound_Failure() {
-        var connections: Connections?
-        if let jsonData = jsonData.data(using: .utf8) {
-            do {
-                connections = try JSONDecoder().decode(Connections.self, from: jsonData)
-            } catch {
-                print("Error decoding JSON: \(error)")
-            }
-        }
+    func test_FindCheapestConnection_Failure_NoConnectionFound() {
+        let connections = loadConnectionsFromJSON()
 
         flightRouteFinder.addConnections(connections?.connections ?? [])
         let result = flightViewModel?.findCheapestRoute(
@@ -289,15 +278,8 @@ final class Flight_ConnectionsTests: XCTestCase {
         }
     }
 
-    func test_FindCheapestConnection_InvalidInput_Failure() {
-        var connections: Connections?
-        if let jsonData = jsonData.data(using: .utf8) {
-            do {
-                connections = try JSONDecoder().decode(Connections.self, from: jsonData)
-            } catch {
-                print("Error decoding JSON: \(error)")
-            }
-        }
+    func test_FindCheapestConnection_Failure_InvalidInput() {
+        let connections = loadConnectionsFromJSON()
 
         flightRouteFinder.addConnections(connections?.connections ?? [])
 
@@ -333,14 +315,7 @@ final class Flight_ConnectionsTests: XCTestCase {
     }
 
     func test_AddConnections_Success() {
-        var connections: Connections?
-        if let jsonData = jsonData.data(using: .utf8) {
-            do {
-                connections = try JSONDecoder().decode(Connections.self, from: jsonData)
-            } catch {
-                XCTFail("Error decoding JSON: \(error)")
-            }
-        }
+        let connections = loadConnectionsFromJSON()
 
         flightRouteFinder.addConnections(
             connections?.connections ?? []

--- a/Flight Connections/Flight ConnectionsTests/Flight_ConnectionsTests.swift
+++ b/Flight Connections/Flight ConnectionsTests/Flight_ConnectionsTests.swift
@@ -199,35 +199,35 @@ final class Flight_ConnectionsTests: XCTestCase {
 
         flightRouteFinder.addConnections(connections?.connections ?? [])
 
-        let result1 = flightViewModel?.findCheapestRoute(departureCity: "Tokyo", destinationCity: "Sydney") ?? .failure(.noValidPath)
-        let result2 = flightViewModel?.findCheapestRoute(departureCity: "London", destinationCity: "Sydney") ?? .failure(.noValidPath)
-        let result3 = flightViewModel?.findCheapestRoute(departureCity: "los angeles", destinationCity: "CAPE TOWN") ?? .failure(.noValidPath)
+        let result1 = flightViewModel?.findCheapestRoute(departureCity: "Tokyo", destinationCity: "Sydney") ?? .failure(.noValidRoute)
+        let result2 = flightViewModel?.findCheapestRoute(departureCity: "London", destinationCity: "Sydney") ?? .failure(.noValidRoute)
+        let result3 = flightViewModel?.findCheapestRoute(departureCity: "los angeles", destinationCity: "CAPE TOWN") ?? .failure(.noValidRoute)
 
         XCTAssertNotNil(result1)
         XCTAssertNotNil(result2)
 
         switch result1 {
-        case .success(let (path, cost)):
+        case .success(let (route, cost)):
             XCTAssertEqual(cost, 100)
-            XCTAssertEqual(path, ["Tokyo", "Sydney"])
+            XCTAssertEqual(route, ["Tokyo", "Sydney"])
 
         case .failure(let error):
             XCTFail("Error finding cheapest route: \(error)")
         }
 
         switch result2 {
-        case .success(let (path, cost)):
+        case .success(let (route, cost)):
             XCTAssertEqual(cost, 320)
-            XCTAssertEqual(path, ["London", "Tokyo", "Sydney"])
+            XCTAssertEqual(route, ["London", "Tokyo", "Sydney"])
 
         case .failure(let error):
             XCTFail("Error finding cheapest route: \(error)")
         }
 
         switch result3 {
-        case .success(let (path, cost)):
+        case .success(let (route, cost)):
             XCTAssertEqual(cost, 450)
-            XCTAssertEqual(path, ["Los Angeles", "Tokyo", "Sydney", "Cape Town"])
+            XCTAssertEqual(route, ["Los Angeles", "Tokyo", "Sydney", "Cape Town"])
 
         case .failure(let error):
             XCTFail("Error finding cheapest route: \(error)")
@@ -245,14 +245,14 @@ final class Flight_ConnectionsTests: XCTestCase {
         }
 
         flightRouteFinder.addConnections(connections?.connections ?? [])
-        let result = flightViewModel?.findCheapestRoute(departureCity: "Tokyo", destinationCity: "Tokyo") ?? .failure(.noValidPath)
+        let result = flightViewModel?.findCheapestRoute(departureCity: "Tokyo", destinationCity: "Tokyo") ?? .failure(.noValidRoute)
 
         XCTAssertNotNil(result)
 
         switch result {
-        case .success(let (path, cost)):
+        case .success(let (route, cost)):
             XCTAssertEqual(cost, 0)
-            XCTAssertEqual(path, ["Tokyo"])
+            XCTAssertEqual(route, ["Tokyo"])
 
         case .failure(let error):
             XCTFail("Error finding cheapest route: \(error)")
@@ -279,10 +279,10 @@ final class Flight_ConnectionsTests: XCTestCase {
 
         switch result {
         case .success:
-            XCTFail("No path should have been found")
+            XCTFail("No route should have been found")
 
         case .failure(let error):
-            XCTAssertEqual(error, .noValidPath)
+            XCTAssertEqual(error, .noValidRoute)
         }
     }
 

--- a/Flight Connections/Flight ConnectionsTests/Flight_ConnectionsTests.swift
+++ b/Flight Connections/Flight ConnectionsTests/Flight_ConnectionsTests.swift
@@ -199,9 +199,9 @@ final class Flight_ConnectionsTests: XCTestCase {
 
         flightRouteFinder.addConnections(connections?.connections ?? [])
 
-        let result1 = flightViewModel?.findCheapestRoute(departureCity: "Tokyo", destinationCity: "Sydney") ?? .failure(.noValidRoute)
-        let result2 = flightViewModel?.findCheapestRoute(departureCity: "London", destinationCity: "Sydney") ?? .failure(.noValidRoute)
-        let result3 = flightViewModel?.findCheapestRoute(departureCity: "los angeles", destinationCity: "CAPE TOWN") ?? .failure(.noValidRoute)
+        let result1 = flightViewModel?.findCheapestRoute(departureCity: "Tokyo", destinationCity: "Sydney") ?? .failure(.noRouteFound)
+        let result2 = flightViewModel?.findCheapestRoute(departureCity: "London", destinationCity: "Sydney") ?? .failure(.noRouteFound)
+        let result3 = flightViewModel?.findCheapestRoute(departureCity: "Los Angeles", destinationCity: "Cape Town") ?? .failure(.noRouteFound)
 
         XCTAssertNotNil(result1)
         XCTAssertNotNil(result2)
@@ -245,7 +245,10 @@ final class Flight_ConnectionsTests: XCTestCase {
         }
 
         flightRouteFinder.addConnections(connections?.connections ?? [])
-        let result = flightViewModel?.findCheapestRoute(departureCity: "Tokyo", destinationCity: "Tokyo") ?? .failure(.noValidRoute)
+        let result = flightViewModel?.findCheapestRoute(
+            departureCity: "Tokyo",
+            destinationCity: "Tokyo"
+        ) ?? .failure(.noRouteFound)
 
         XCTAssertNotNil(result)
 
@@ -282,7 +285,50 @@ final class Flight_ConnectionsTests: XCTestCase {
             XCTFail("No route should have been found")
 
         case .failure(let error):
-            XCTAssertEqual(error, .noValidRoute)
+            XCTAssertEqual(error, .noRouteFound)
+        }
+    }
+
+    func test_FindCheapestConnection_InvalidInput_Failure() {
+        var connections: Connections?
+        if let jsonData = jsonData.data(using: .utf8) {
+            do {
+                connections = try JSONDecoder().decode(Connections.self, from: jsonData)
+            } catch {
+                print("Error decoding JSON: \(error)")
+            }
+        }
+
+        flightRouteFinder.addConnections(connections?.connections ?? [])
+
+        let result1 = flightViewModel?.findCheapestRoute(
+            departureCity: "Guimarães",
+            destinationCity: ""
+        ) ?? .success(([""], 10))
+
+        XCTAssertNotNil(result1)
+
+        switch result1 {
+        case .success:
+            XCTFail("No route should have been found")
+
+        case .failure(let error):
+            XCTAssertEqual(error, .invalidInput)
+        }
+
+        let result2 = flightViewModel?.findCheapestRoute(
+            departureCity: "",
+            destinationCity: "Guimarães"
+        ) ?? .success(([""], 10))
+
+        XCTAssertNotNil(result2)
+
+        switch result2 {
+        case .success:
+            XCTFail("No route should have been found")
+
+        case .failure(let error):
+            XCTAssertEqual(error, .invalidInput)
         }
     }
 


### PR DESCRIPTION
- Created `enum RouteFinderError` in order to handle the errors from `fetchCheapestRoute(from:to:)`
- Created `struct City` so we can map from `Connection` into `City` for simplicity
- Removed unnecessary `import Foundation` from various files
- Created `FlightRouteFinder` and `FlightRouteFinderProtocol` - This `class` (and `protocol`) should be responsible for the search (using the **`Dijkstra`** algorithm) for the cheapest route between two cities
- Updated `FlightConnectionsViewModel` so that we can now `findCheapestRoute`
- Created `CalculateRouteButton` to trigger the calculations
- Created `RouteResultView ` and `RouteResultViewModel` so we can present the cheapest route (or error)
- Created `ConnectionSelectionView` so we can have user inputs
- Updated previous tests and added new ones due to the route finder implementation